### PR TITLE
fix: bugs with v1.3.0

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,9 @@ class LumigoPlugin {
 			for (const func of functions) {
 				const handler = await this.createWrappedNodejsFunction(func, token);
 				// replace the function handler to the wrapped function
-				this.verboseLog(`setting [${func.localName}]'s handler to [${handler}]...`);
+				this.verboseLog(
+					`setting [${func.localName}]'s handler to [${handler}]...`
+				);
 				this.serverless.service.functions[func.localName].handler = handler;
 			}
 		} else if (runtime === "python") {
@@ -53,7 +55,9 @@ class LumigoPlugin {
 			for (const func of functions) {
 				const handler = await this.createWrappedPythonFunction(func, token);
 				// replace the function handler to the wrapped function
-				this.verboseLog(`setting [${func.localName}]'s handler to [${handler}]...`);
+				this.verboseLog(
+					`setting [${func.localName}]'s handler to [${handler}]...`
+				);
 				this.serverless.service.functions[func.localName].handler = handler;
 			}
 		}

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -68,7 +68,7 @@ beforeEach(() => {
 	childProcess.exec.mockImplementation((cmd, cb) => cb());
 	const LumigoPlugin = require("./index");
 	lumigo = new LumigoPlugin(serverless, {});
-  
+
 	delete process.env.SLS_DEBUG;
 });
 
@@ -127,17 +127,19 @@ describe("Lumigo plugin (node.js)", () => {
 				assertLumigoIsIncluded();
 			});
 		});
-    
+
 		describe("if verbose logging is enabled", () => {
 			beforeEach(() => {
 				process.env.SLS_DEBUG = "*";
 			});
-      
+
 			test("it should publish debug messages", async () => {
 				await lumigo.afterPackageInitialize();
 
 				const logs = log.mock.calls.map(x => x[0]);
-				expect(logs).toContain("serverless-lumigo: setting [hello]'s handler to [_lumigo/hello.world]...");
+				expect(logs).toContain(
+					"serverless-lumigo: setting [hello]'s handler to [_lumigo/hello.world]..."
+				);
 			});
 		});
 	});
@@ -196,17 +198,19 @@ describe("Lumigo plugin (node.js)", () => {
 				assertLumigoIsIncluded();
 			});
 		});
-    
+
 		describe("if verbose logging is enabled", () => {
 			beforeEach(() => {
 				process.env.SLS_DEBUG = "*";
 			});
-      
+
 			test("it should publish debug messages", async () => {
 				await lumigo.afterPackageInitialize();
 
 				const logs = log.mock.calls.map(x => x[0]);
-				expect(logs).toContain("serverless-lumigo: setting [hello]'s handler to [_lumigo/hello.world]...");
+				expect(logs).toContain(
+					"serverless-lumigo: setting [hello]'s handler to [_lumigo/hello.world]..."
+				);
 			});
 		});
 	});
@@ -408,12 +412,12 @@ lumigo_tracer`);
 				assertLumigoIsIncluded();
 			});
 		});
-    
+
 		describe("if verbose logging is enabled", () => {
 			beforeEach(() => {
 				process.env.SLS_DEBUG = "*";
 			});
-      
+
 			test("it should publish debug messages", async () => {
 				fs.pathExistsSync.mockReturnValue(true);
 				fs.readFile.mockReturnValue(`
@@ -424,7 +428,9 @@ lumigo_tracer`);
 				await lumigo.afterPackageInitialize();
 
 				const logs = log.mock.calls.map(x => x[0]);
-				expect(logs).toContain("serverless-lumigo: setting [hello]'s handler to [_lumigo/hello.world]...");
+				expect(logs).toContain(
+					"serverless-lumigo: setting [hello]'s handler to [_lumigo/hello.world]..."
+				);
 			});
 		});
 	});


### PR DESCRIPTION
Addresses two separate issues:
* the handler path is not updated after wrapping the functions
* the node.js tracer package installed doesn't match the one referenced in the wrapper function