### PR TITLE
Fix: Deploying a single function 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -133,9 +133,11 @@ class LumigoPlugin {
 	}
 
 	getFunctionsToWrap(service, functionNames) {
+		functionNames = functionNames || this.serverless.service.getAllFunctions();
+
 		const functions = service
 			.getAllFunctions()
-			.filter(localName => !functionNames || functionNames.includes(localName))
+			.filter(localName => functionNames.includes(localName))
 			.map(localName => {
 				const x = _.cloneDeep(service.getFunction(localName));
 				x.localName = localName;

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -94,154 +94,155 @@ describe("Invalid plugin configuration", () => {
 });
 
 describe("Lumigo plugin (node.js)", () => {
-	describe.each`
-		runtime         |
-		${"nodejs8.10"}
-		${"nodejs10.x"}
-	`("when using runtime $runtime", ({ runtime }) => {
-	beforeEach(() => {
-		serverless.service.provider.runtime = runtime;
-	});
-
-	test("edgeHost configuration present, should appear in the wrapped code", async () => {
-		serverless.service.custom.lumigo["edgeHost"] = edgeHost;
-		await lumigo.afterPackageInitialize();
-
-		expect(fs.outputFile).toBeCalledWith(
-			__dirname + "/_lumigo/hello.js",
-			expect.toContainAllStrings(`edgeHost: '${edgeHost}'`)
-		);
-	});
-
-	test("edgeHost configuration not present, should not appear in the wrapped code", async () => {
-		await lumigo.afterPackageInitialize();
-
-		expect(fs.outputFile).toBeCalledWith(
-			__dirname + "/_lumigo/hello.js",
-			expect.not.toContainAllStrings(`edgeHost: '${edgeHost}'`)
-		);
-	});
-
-	test("it should wrap all functions after package initialize", async () => {
-		await lumigo.afterPackageInitialize();
-		assertNodejsFunctionsAreWrapped();
-	});
-
-	test("it should clean up after deployment artefact is created", async () => {
-		await lumigo.afterCreateDeploymentArtifacts();
-		assertNodejsFunctionsAreCleanedUp();
-	});
-
-	describe("there are no functions", () => {
+	describe.each([["nodejs8.10"], ["nodejs10.x"]])("when using runtime %s", runtime => {
 		beforeEach(() => {
-			serverless.service.functions = {};
+			serverless.service.provider.runtime = runtime;
 		});
 
-		test("it shouldn't wrap any function after package initialize", async () => {
+		test("edgeHost configuration present, should appear in the wrapped code", async () => {
+			serverless.service.custom.lumigo["edgeHost"] = edgeHost;
 			await lumigo.afterPackageInitialize();
-			assertFunctionsAreNotWrapped();
+
+			expect(fs.outputFile).toBeCalledWith(
+				__dirname + "/_lumigo/hello.js",
+				expect.toContainAllStrings(`edgeHost: '${edgeHost}'`)
+			);
 		});
 
-		test("it does nothing after deployment artefact is created", async () => {
+		test("edgeHost configuration not present, should not appear in the wrapped code", async () => {
+			await lumigo.afterPackageInitialize();
+
+			expect(fs.outputFile).toBeCalledWith(
+				__dirname + "/_lumigo/hello.js",
+				expect.not.toContainAllStrings(`edgeHost: '${edgeHost}'`)
+			);
+		});
+
+		test("it should wrap all functions after package initialize", async () => {
+			await lumigo.afterPackageInitialize();
+			assertNodejsFunctionsAreWrapped();
+		});
+
+		test("it should clean up after deployment artefact is created", async () => {
 			await lumigo.afterCreateDeploymentArtifacts();
-			assertNothingHappens();
-		});
-	});
-
-	describe("when functions are packaged individually", () => {
-		beforeEach(() => {
-			serverless.service.package = {
-				individually: true
-			};
+			assertNodejsFunctionsAreCleanedUp();
 		});
 
-		test("if package.include is not set, it's initialized with _lumigo/*", async () => {
-			await lumigo.afterPackageInitialize();
-			assertLumigoIsIncluded();
+		describe("there are no functions", () => {
+			beforeEach(() => {
+				serverless.service.functions = {};
+			});
+
+			test("it shouldn't wrap any function after package initialize", async () => {
+				await lumigo.afterPackageInitialize();
+				assertFunctionsAreNotWrapped();
+			});
+
+			test("it does nothing after deployment artefact is created", async () => {
+				await lumigo.afterCreateDeploymentArtifacts();
+				assertNothingHappens();
+			});
 		});
 
-		test("if package.include is set, it adds _lumigo/* to the array", async () => {
-			Object.values(serverless.service.functions).forEach(fun => {
-				fun.package = {
-					include: ["node_modules/**/*"]
+		describe("when functions are packaged individually", () => {
+			beforeEach(() => {
+				serverless.service.package = {
+					individually: true
 				};
 			});
 
-			await lumigo.afterPackageInitialize();
-			assertLumigoIsIncluded();
+			test("if package.include is not set, it's initialized with _lumigo/*", async () => {
+				await lumigo.afterPackageInitialize();
+				assertLumigoIsIncluded();
+			});
+
+			test("if package.include is set, it adds _lumigo/* to the array", async () => {
+				Object.values(serverless.service.functions).forEach(fun => {
+					fun.package = {
+						include: ["node_modules/**/*"]
+					};
+				});
+
+				await lumigo.afterPackageInitialize();
+				assertLumigoIsIncluded();
+			});
+		});
+
+		describe("if verbose logging is enabled", () => {
+			beforeEach(() => {
+				process.env.SLS_DEBUG = "*";
+			});
+
+			test("it should publish debug messages", async () => {
+				await lumigo.afterPackageInitialize();
+
+				const logs = log.mock.calls.map(x => x[0]);
+				expect(logs).toContain(
+					"serverless-lumigo: setting [hello]'s handler to [_lumigo/hello.world]..."
+				);
+			});
+		});
+
+		describe("when nodePackageManager is Yarn", () => {
+			beforeEach(() => {
+				serverless.service.custom.lumigo.nodePackageManager = "yarn";
+			});
+
+			test("it should install with Yarn", async () => {
+				await lumigo.afterPackageInitialize();
+
+				expect(childProcess.execSync).toBeCalledWith(
+					"yarn add @lumigo/tracer@latest",
+					"utf8"
+				);
+			});
+
+			test("it should uninstall with Yarn", async () => {
+				await lumigo.afterCreateDeploymentArtifacts();
+
+				expect(childProcess.execSync).toBeCalledWith(
+					"yarn remove @lumigo/tracer",
+					"utf8"
+				);
+			});
+		});
+
+		describe("when nodePackageManager is not NPM or Yarn", () => {
+			beforeEach(() => {
+				serverless.service.custom.lumigo.nodePackageManager = "whatever";
+			});
+
+			test("it should error on install", async () => {
+				await expect(lumigo.afterPackageInitialize()).rejects.toThrow(
+					"No Node.js package manager found. Please install either NPM or Yarn."
+				);
+			});
+
+			test("it should error on uninstall", async () => {
+				await expect(lumigo.afterCreateDeploymentArtifacts()).rejects.toThrow(
+					"No Node.js package manager found. Please install either NPM or Yarn."
+				);
+			});
+		});
+
+		describe("when deploying a single function using 'sls deploy -f'", () => {
+			beforeEach(async () => {
+				options.function = "hello";
+				await lumigo.afterDeployFunctionInitialize();
+			});
+
+			it("should only wrap one function", () => {
+				expect(fs.outputFile).toBeCalledTimes(1);
+				assertFileOutput({
+					filename: "hello.js",
+					requireHandler: "require('../hello').world"
+				});
+				expect(serverless.service.functions.hello.handler).toBe(
+					"_lumigo/hello.world"
+				);
+			});
 		});
 	});
-
-	describe("if verbose logging is enabled", () => {
-		beforeEach(() => {
-			process.env.SLS_DEBUG = "*";
-		});
-
-		test("it should publish debug messages", async () => {
-			await lumigo.afterPackageInitialize();
-
-			const logs = log.mock.calls.map(x => x[0]);
-			expect(logs).toContain(
-				"serverless-lumigo: setting [hello]'s handler to [_lumigo/hello.world]..."
-			);
-		});
-	});
-
-	describe("when nodePackageManager is Yarn", () => {
-		beforeEach(() => {
-			serverless.service.custom.lumigo.nodePackageManager = "yarn";
-		});
-
-		test("it should install with Yarn", async () => {
-			await lumigo.afterPackageInitialize();
-
-			expect(childProcess.execSync).toBeCalledWith(
-				"yarn add @lumigo/tracer@latest",
-				"utf8"
-			);
-		});
-
-		test("it should uninstall with Yarn", async () => {
-			await lumigo.afterCreateDeploymentArtifacts();
-
-			expect(childProcess.execSync).toBeCalledWith(
-				"yarn remove @lumigo/tracer",
-				"utf8"
-			);
-		});
-	});
-
-	describe("when nodePackageManager is not NPM or Yarn", () => {
-		beforeEach(() => {
-			serverless.service.custom.lumigo.nodePackageManager = "whatever";
-		});
-
-		test("it should error on install", async () => {
-			await expect(lumigo.afterPackageInitialize()).rejects.toThrow(
-				"No Node.js package manager found. Please install either NPM or Yarn."
-			);
-		});
-
-		test("it should error on uninstall", async () => {
-			await expect(lumigo.afterCreateDeploymentArtifacts()).rejects.toThrow(
-				"No Node.js package manager found. Please install either NPM or Yarn."
-			);
-		});
-	});
-
-	describe("when deploying a single function using 'sls deploy -f'", () => {
-		beforeEach(async () => {
-			options.function = "hello";
-			await lumigo.afterDeployFunctionInitialize();
-		});
-
-		it("should only wrap one function", () => {
-			expect(fs.outputFile).toBeCalledTimes(1);
-			assertFileOutput({ filename: "hello.js", requireHandler: "require('../hello').world" });
-			expect(serverless.service.functions.hello.handler).toBe("_lumigo/hello.world");
-		});
-	});
-});
 });
 
 describe("Lumigo plugin (python)", () => {
@@ -502,7 +503,10 @@ function assertNodejsFunctionsAreWrapped() {
 	expect(fs.outputFile).toBeCalledTimes(6);
 	[
 		{ filename: "hello.js", requireHandler: "require('../hello').world" },
-		{ filename: "hello.world.js",	requireHandler: "require('../hello.world').handler"	},
+		{
+			filename: "hello.world.js",
+			requireHandler: "require('../hello.world').handler"
+		},
 		{ filename: "foo.js", requireHandler: "require('../foo_bar').handler" },
 		{ filename: "bar.js", requireHandler: "require('../foo_bar').handler" },
 		{ filename: "jet.js", requireHandler: "require('../foo/foo/bar').handler" },


### PR DESCRIPTION
Resolves #23 

- Fixed by wrapping the function in the `deploy:function` lifecycle as well.  
- Did some refactoring to be able to reuse existing code
- Added `nodejs` tests as well and DRYed up the code a little bit there as well