### PR TITLE
fix: replace slashes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -447,7 +447,8 @@ module.exports.${handlerFuncName} = tracer.trace(handler);`;
 
 		// convert from abs path to relative path, e.g.
 		// /Users/username/source/project/_lumigo/hello.world.js -> _lumigo/hello.world.js
-		const newFilePath = path.relative(this.serverless.config.servicePath, filePath);
+		// Make sure to support windows paths
+		const newFilePath = path.relative(this.serverless.config.servicePath, filePath).replace("\\", "/");
 		// e.g. _lumigo/hello.world.js -> _lumigo/hello.world.handler
 		return newFilePath.substr(0, newFilePath.lastIndexOf(".") + 1) + handlerFuncName;
 	}

--- a/src/index.js
+++ b/src/index.js
@@ -448,7 +448,9 @@ module.exports.${handlerFuncName} = tracer.trace(handler);`;
 		// convert from abs path to relative path, e.g.
 		// /Users/username/source/project/_lumigo/hello.world.js -> _lumigo/hello.world.js
 		// Make sure to support windows paths
-		const newFilePath = path.relative(this.serverless.config.servicePath, filePath).replace("\\", "/");
+		const newFilePath = path
+			.relative(this.serverless.config.servicePath, filePath)
+			.replace("\\", "/");
 		// e.g. _lumigo/hello.world.js -> _lumigo/hello.world.handler
 		return newFilePath.substr(0, newFilePath.lastIndexOf(".") + 1) + handlerFuncName;
 	}


### PR DESCRIPTION
Avoid issues like 
```
{
    "errorType": "Runtime.ImportModuleError",
    "errorMessage": "Error: Cannot find module '_lumigo\\first'\nRequire stack:\n- /var/runtime/UserFunction.js\n- /var/runtime/index.js",
    "trace": [
        "Runtime.ImportModuleError: Error: Cannot find module '_lumigo\\first'",
        "Require stack:",
        "- /var/runtime/UserFunction.js",
        "- /var/runtime/index.js",
        "    at _loadUserApp (/var/runtime/UserFunction.js:100:13)",
        "    at Object.module.exports.load (/var/runtime/UserFunction.js:140:17)",
        "    at Object.<anonymous> (/var/runtime/index.js:43:30)",
        "    at Module._compile (internal/modules/cjs/loader.js:999:30)",
        "    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)",
        "    at Module.load (internal/modules/cjs/loader.js:863:32)",
        "    at Function.Module._load (internal/modules/cjs/loader.js:708:14)",
        "    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:60:12)",
        "    at internal/main/run_main_module.js:17:47"
    ]
}
```
When running sls deploy under windows