### PR TITLE
feat: add schema validation to the plugin

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,27 +45,29 @@ class LumigoPlugin {
 	}
 
 	extendServerlessSchema() {
-		this.serverless.configSchemaHandler.defineFunctionProperties("aws", {
-			type: "object",
-			properties: {
-				lumigo: {
-					type: "object",
-					properties: {
-						token: { type: "string" },
-						enabled: { type: "boolean" },
-						pinVersion: { type: "string" },
-						skipInstallNodeTracer: { type: "boolean" },
-						skipReqCheck: { type: "boolean" },
-						step_function: { type: "boolean" },
-						useLayers: { type: "boolean" },
-						nodePackageManager: { type: "string" },
-						nodeLayerVersion: { type: "string" },
-						pythonLayerVersion: { type: "string" }
-					},
-					additionalProperties: false
-				}
-			}
-		});
+    if (this.serverless.configSchemaHandler) {
+      this.serverless.configSchemaHandler.defineFunctionProperties("aws", {
+        type: "object",
+        properties: {
+          lumigo: {
+            type: "object",
+            properties: {
+              token: {type: "string"},
+              enabled: {type: "boolean"},
+              pinVersion: {type: "string"},
+              skipInstallNodeTracer: {type: "boolean"},
+              skipReqCheck: {type: "boolean"},
+              step_function: {type: "boolean"},
+              useLayers: {type: "boolean"},
+              nodePackageManager: {type: "string"},
+              nodeLayerVersion: {type: "string"},
+              pythonLayerVersion: {type: "string"}
+            },
+            additionalProperties: false
+          }
+        }
+      });
+    }
 	}
 
 	get nodePackageManager() {

--- a/src/index.js
+++ b/src/index.js
@@ -41,6 +41,31 @@ class LumigoPlugin {
 				this
 			)
 		};
+		this.extendServerlessSchema();
+	}
+
+	extendServerlessSchema() {
+		this.serverless.configSchemaHandler.defineFunctionProperties("aws", {
+			type: "object",
+			properties: {
+				lumigo: {
+					type: "object",
+					properties: {
+						token: { type: "string" },
+						enabled: { type: "boolean" },
+						pinVersion: { type: "string" },
+						skipInstallNodeTracer: { type: "boolean" },
+						skipReqCheck: { type: "boolean" },
+						step_function: { type: "boolean" },
+						useLayers: { type: "boolean" },
+						nodePackageManager: { type: "string" },
+						nodeLayerVersion: { type: "string" },
+						pythonLayerVersion: { type: "string" }
+					},
+					additionalProperties: false
+				}
+			}
+		});
 	}
 
 	get nodePackageManager() {

--- a/src/index.js
+++ b/src/index.js
@@ -45,29 +45,29 @@ class LumigoPlugin {
 	}
 
 	extendServerlessSchema() {
-    if (this.serverless.configSchemaHandler) {
-      this.serverless.configSchemaHandler.defineFunctionProperties("aws", {
-        type: "object",
-        properties: {
-          lumigo: {
-            type: "object",
-            properties: {
-              token: {type: "string"},
-              enabled: {type: "boolean"},
-              pinVersion: {type: "string"},
-              skipInstallNodeTracer: {type: "boolean"},
-              skipReqCheck: {type: "boolean"},
-              step_function: {type: "boolean"},
-              useLayers: {type: "boolean"},
-              nodePackageManager: {type: "string"},
-              nodeLayerVersion: {type: "string"},
-              pythonLayerVersion: {type: "string"}
-            },
-            additionalProperties: false
-          }
-        }
-      });
-    }
+		if (this.serverless.configSchemaHandler) {
+			this.serverless.configSchemaHandler.defineFunctionProperties("aws", {
+				type: "object",
+				properties: {
+					lumigo: {
+						type: "object",
+						properties: {
+							token: { type: "string" },
+							enabled: { type: "boolean" },
+							pinVersion: { type: "string" },
+							skipInstallNodeTracer: { type: "boolean" },
+							skipReqCheck: { type: "boolean" },
+							step_function: { type: "boolean" },
+							useLayers: { type: "boolean" },
+							nodePackageManager: { type: "string" },
+							nodeLayerVersion: { type: "string" },
+							pythonLayerVersion: { type: "string" }
+						},
+						additionalProperties: false
+					}
+				}
+			});
+		}
 	}
 
 	get nodePackageManager() {


### PR DESCRIPTION
The serverless framework added a schema validation feature:
https://github.com/juanjoDiaz/serverless-plugin-warmup/issues/222
Which caused the plugin to throw the following warning:
![image](https://user-images.githubusercontent.com/47108628/148239791-9cb5bef2-45b9-40b7-ac2f-90919da08408.png)

In this PR, I added a schema validation using the docs: https://www.serverless.com/framework/docs/guides/plugins/custom-configuration

First, the warning was disappeared.
Moreover, I added a type checking to the input parameters, e.g.:
![image](https://user-images.githubusercontent.com/47108628/148240094-679755ae-e450-4d56-aac4-71a2d3f55856.png)
And properties validation, e.g.:
![image](https://user-images.githubusercontent.com/47108628/148240144-ff48950e-0320-4d7c-90f4-90d6c1a699f4.png)
