### PR TITLE
Enable es6 modules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,8 @@
     "jest": true
 	},
 	"parserOptions": {
-		"ecmaVersion": 2017
+		"ecmaVersion": 2017,
+		"sourceType": "module"
 	},
 	"rules": {
 		"indent": ["error", "tab"],

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ provider:
 custom:
   lumigo:
     token: <YOUR TOKEN GOES HERE>
-    nodeUseModule: true
+    nodeUseESModule: true
     nodeModuleFileExtension: js
 ```
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,20 @@ custom:
     skipInstallNodeTracer: true # defaults to false
 ```
 
+In case you are using ES Modules for Lambda handlers.
+
+```yml
+provider:
+  name: aws
+  runtime: nodejs14.x
+
+custom:
+  lumigo:
+    token: <YOUR TOKEN GOES HERE>
+    nodeUseModule: true
+    nodeModuleFileExtension: js
+```
+
 ## Python functions
 
 For Python functions, we recommend using the [serverless-python-requirements](https://www.npmjs.com/package/serverless-python-requirements) plugin to help you manage your dependencies. You should have the following in your `requirements.txt`:

--- a/integration-test/nodejs-esm/.gitignore
+++ b/integration-test/nodejs-esm/.gitignore
@@ -1,0 +1,7 @@
+# package directories
+node_modules
+jspm_packages
+
+# Serverless directories
+.serverless
+/package-lock.json

--- a/integration-test/nodejs-esm/handler.js
+++ b/integration-test/nodejs-esm/handler.js
@@ -1,0 +1,3 @@
+export const hello = async event => {
+	return { message: "Hello Lumigo!", event };
+};

--- a/integration-test/nodejs-esm/package.json
+++ b/integration-test/nodejs-esm/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "nodejs",
+  "version": "1.0.0",
+  "description": "",
+  "main": "handler.js",
+  "type": "module",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/integration-test/nodejs-esm/serverless.yml
+++ b/integration-test/nodejs-esm/serverless.yml
@@ -1,0 +1,24 @@
+service: serverless-plugin-nodejs-esm
+
+custom:
+  lumigo:
+    token: t_b9222642efc14985baaed
+    nodePackageManager: npm
+    nodeUseESModule: true
+    nodeModuleFileExtension: js
+    edgeHost: test.execute-api.us-west-2.amazonaws.com
+    pinVersion: 1.30.0
+
+provider:
+  name: aws
+  runtime: nodejs14.x
+  environment:
+    LUMIGO_TRACER_HOST: "test.execute-api.us-west-2.amazonaws.com"
+    LUMIGO_DEBUG: "TRUE"
+
+functions:
+  test:
+    handler: handler.hello
+
+plugins:
+  - ./../../src/index

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -28,6 +28,28 @@ echo
 sls remove --stage $random
 popd
 
+pushd integration-test/nodejs-esm
+
+random=$RANDOM
+
+echo "** Testing NodeJS with ES Module **"
+echo "********************"
+echo
+echo
+
+echo "** Deploying **"
+echo
+sls deploy --force --stage $random
+
+echo "** Testing **"
+echo
+sls invoke -l -f test --stage $random | grep "#LUMIGO#"
+
+echo "** Removing stack **"
+echo
+sls remove --stage $random
+popd
+
 echo "** Testing Python **"
 echo "********************"
 echo

--- a/src/index.js
+++ b/src/index.js
@@ -439,7 +439,11 @@ Consider using the serverless-python-requirements plugin to help you package Pyt
 			throw new this.serverless.classes.Error("Lumigo's tracer token is undefined");
 		}
 		let configuration = [];
-		options = _.omit(options, ["nodePackageManager","nodeUseESModule", "nodeModuleFileExtension"]);
+		options = _.omit(options, [
+			"nodePackageManager",
+			"nodeUseESModule",
+			"nodeModuleFileExtension"
+		]);
 		for (const [key, value] of Object.entries(options)) {
 			if (String(value).toLowerCase() === "true") {
 				configuration.push(`${key}${equalityToken}${trueValue}`);
@@ -473,11 +477,12 @@ Consider using the serverless-python-requirements plugin to help you package Pyt
 		// e.g. functions/hello.world.handler -> handler
 		const handlerFuncName = handler.substr(handler.lastIndexOf(".") + 1);
 
-        
+		// too shorten the file extension ref for prettier during test:all
+		const fileExt = this.nodeModuleFileExtension;
 
 		const wrappedESMFunction = `
 import lumigo from '@lumigo/tracer'
-import {${handlerFuncName} as originalHandler} from '../${handlerModulePath}.${this.nodeModuleFileExtension}'
+import {${handlerFuncName} as originalHandler} from '../${handlerModulePath}.${fileExt}'
 const tracer = lumigo({ ${this.getNodeTracerParameters(token, options)} })
 
 export const ${handlerFuncName} = tracer.trace(originalHandler);`;
@@ -490,7 +495,9 @@ const handler = require('../${handlerModulePath}').${handlerFuncName};
 
 module.exports.${handlerFuncName} = tracer.trace(handler);`;
 
-		const wrappedFunction = (this.nodeUseESModule) ? wrappedESMFunction : wrappedCJSFunction;
+		const wrappedFunction = this.nodeUseESModule
+			? wrappedESMFunction
+			: wrappedCJSFunction;
 
 		const fileName = localName + ".js";
 		// e.g. hello.world.js -> /Users/username/source/project/_lumigo/hello.world.js

--- a/src/index.js
+++ b/src/index.js
@@ -61,7 +61,7 @@ class LumigoPlugin {
 							useLayers: { type: "boolean" },
 							nodePackageManager: { type: "string" },
 							nodeLayerVersion: { type: "string" },
-							nodeUseModule: { type: "boolean" },
+							nodeUseESModule: { type: "boolean" },
 							nodeModuleFileExtension: { type: "string" },
 							pythonLayerVersion: { type: "string" }
 						},
@@ -80,8 +80,8 @@ class LumigoPlugin {
 		).toLowerCase();
 	}
 
-	get nodeUseModule() {
-		return _.get(this.serverless.service, "custom.lumigo.nodeUseModule", false);
+	get nodeUseESModule() {
+		return _.get(this.serverless.service, "custom.lumigo.nodeUseESModule", false);
 	}
 
 	get nodePackageManager() {
@@ -439,7 +439,7 @@ Consider using the serverless-python-requirements plugin to help you package Pyt
 			throw new this.serverless.classes.Error("Lumigo's tracer token is undefined");
 		}
 		let configuration = [];
-		options = _.omit(options, ["nodePackageManager","nodeUseModule", "nodeModuleFileExtension"]);
+		options = _.omit(options, ["nodePackageManager","nodeUseESModule", "nodeModuleFileExtension"]);
 		for (const [key, value] of Object.entries(options)) {
 			if (String(value).toLowerCase() === "true") {
 				configuration.push(`${key}${equalityToken}${trueValue}`);
@@ -490,7 +490,7 @@ const handler = require('../${handlerModulePath}').${handlerFuncName};
 
 module.exports.${handlerFuncName} = tracer.trace(handler);`;
 
-		const wrappedFunction = (this.nodeUseModule) ? wrappedESMFunction : wrappedCJSFunction;
+		const wrappedFunction = (this.nodeUseESModule) ? wrappedESMFunction : wrappedCJSFunction;
 
 		const fileName = localName + ".js";
 		// e.g. hello.world.js -> /Users/username/source/project/_lumigo/hello.world.js

--- a/src/index.js
+++ b/src/index.js
@@ -478,7 +478,7 @@ Consider using the serverless-python-requirements plugin to help you package Pyt
 		const wrappedESMFunction = `
 import lumigo from '@lumigo/tracer'
 import {${handlerFuncName} as lumigoHandler} from '../${handlerModulePath}.${this.nodeModuleFileExtension}'
-const tracer = lumigo(${this.getNodeTracerParameters(token, options)})
+const tracer = lumigo({ ${this.getNodeTracerParameters(token, options)} })
 
 export const ${handlerFuncName} = tracer.trace(lumigoHandler);`;
 

--- a/src/index.js
+++ b/src/index.js
@@ -477,10 +477,10 @@ Consider using the serverless-python-requirements plugin to help you package Pyt
 
 		const wrappedESMFunction = `
 import lumigo from '@lumigo/tracer'
-import {${handlerFuncName} as lumigoHandler} from '../${handlerModulePath}.${this.nodeModuleFileExtension}'
+import {${handlerFuncName} as originalHandler} from '../${handlerModulePath}.${this.nodeModuleFileExtension}'
 const tracer = lumigo({ ${this.getNodeTracerParameters(token, options)} })
 
-export const ${handlerFuncName} = tracer.trace(lumigoHandler);`;
+export const ${handlerFuncName} = tracer.trace(originalHandler);`;
 
 		const wrappedCJSFunction = `
 const tracer = require("@lumigo/tracer")({

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -125,9 +125,9 @@ describe("Lumigo plugin (node.js)", () => {
 		});
 
 		if(runtime === "nodejs14.x"){
-			describe("when nodeUseModule is true", () => {
+			describe("when nodeUseESModule is true", () => {
 				beforeEach(() => {
-					serverless.service.custom.lumigo.nodeUseModule = true;
+					serverless.service.custom.lumigo.nodeUseESModule = true;
 				});
 
 				test("it should wrap all non-skipped functions after package initialize ES style", async () => {
@@ -138,7 +138,7 @@ describe("Lumigo plugin (node.js)", () => {
 
 			describe("when nodeModuleFileExtension is mjs", () => {
 				beforeEach(async () => {
-					serverless.service.custom.lumigo.nodeUseModule = true;
+					serverless.service.custom.lumigo.nodeUseESModule = true;
 					serverless.service.custom.lumigo.nodeModuleFileExtension = "mjs";
 					options.function = "hello";
 					await lumigo.afterDeployFunctionInitialize();
@@ -157,9 +157,9 @@ describe("Lumigo plugin (node.js)", () => {
 			});
 		}
 
-		describe("when nodeUseModule is false", () => {
+		describe("when nodeUseESModule is false", () => {
 			beforeEach(() => {
-				serverless.service.custom.lumigo.nodeUseModule = false;
+				serverless.service.custom.lumigo.nodeUseESModule = false;
 			});
 
 			test("it should wrap all non-skipped functions after package initialize CJS style", async () => {
@@ -168,7 +168,7 @@ describe("Lumigo plugin (node.js)", () => {
 			});
 		});
 
-		describe("when nodeUseModule is not set", () => {
+		describe("when nodeUseESModule is not set", () => {
 			test("it should wrap all non-skipped functions after package initialize CJS style", async () => {
 				await lumigo.afterPackageInitialize();
 				assertNodejsFunctionsAreWrappedCJS();

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -101,7 +101,8 @@ describe("Invalid plugin configuration", () => {
 });
 
 describe("Lumigo plugin (node.js)", () => {
-	describe.each([["nodejs14.x"], ["nodejs12.x"], ["nodejs10.x"]])("when using runtime %s", runtime => {
+	const runtimes = [["nodejs14.x"], ["nodejs12.x"], ["nodejs10.x"]];
+	describe.each(runtimes)("when using runtime %s", runtime => {
 		beforeEach(() => {
 			serverless.service.provider.runtime = runtime;
 		});
@@ -124,7 +125,7 @@ describe("Lumigo plugin (node.js)", () => {
 			);
 		});
 
-		if(runtime === "nodejs14.x"){
+		if (runtime === "nodejs14.x") {
 			describe("when nodeUseESModule is true", () => {
 				beforeEach(() => {
 					serverless.service.custom.lumigo.nodeUseESModule = true;
@@ -146,9 +147,11 @@ describe("Lumigo plugin (node.js)", () => {
 
 				test("should add mjs as file extension", async () => {
 					assertFileOutputES({
-						filename: "hello.js", 
-						importStatement: "import {world as originalHandler} from '../hello.mjs'",
-						exportStatement: "export const world = tracer.trace(originalHandler);"
+						filename: "hello.js",
+						importStatement:
+							"import {world as originalHandler} from '../hello.mjs'",
+						exportStatement:
+							"export const world = tracer.trace(originalHandler);"
 					});
 					expect(serverless.service.functions.hello.handler).toBe(
 						"_lumigo/hello.world"
@@ -876,31 +879,34 @@ function assertNodejsFunctionsAreWrappedES() {
 
 	expect(fs.outputFile).toBeCalledTimes(6);
 	[
-		{ 
-			filename: "hello.js", 
+		{
+			filename: "hello.js",
 			importStatement: "import {world as originalHandler} from '../hello.js'",
 			exportStatement: "export const world = tracer.trace(originalHandler);"
 		},
-		{ 
-			filename: "hello.world.js", 
-			importStatement: "import {handler as originalHandler} from '../hello.world.js'",
+		{
+			filename: "hello.world.js",
+			importStatement:
+				"import {handler as originalHandler} from '../hello.world.js'",
 			exportStatement: "export const handler = tracer.trace(originalHandler);"
 		},
-		{ 
-			filename: "foo.js", 
+		{
+			filename: "foo.js",
 			importStatement: "import {handler as originalHandler} from '../foo_bar.js'",
 			exportStatement: "export const handler = tracer.trace(originalHandler);"
 		},
-		{ 
-			filename: "jet.js", 
-			importStatement: "import {handler as originalHandler} from '../foo/foo/bar.js'",
+		{
+			filename: "jet.js",
+			importStatement:
+				"import {handler as originalHandler} from '../foo/foo/bar.js'",
 			exportStatement: "export const handler = tracer.trace(originalHandler);"
 		},
-		{ 
-			filename: "pack.js", 
-			importStatement: "import {handler as originalHandler} from '../foo.bar/zoo.js'",
+		{
+			filename: "pack.js",
+			importStatement:
+				"import {handler as originalHandler} from '../foo.bar/zoo.js'",
 			exportStatement: "export const handler = tracer.trace(originalHandler);"
-		},
+		}
 	].forEach(assertFileOutputES);
 
 	const functions = serverless.service.functions;

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -118,7 +118,6 @@ describe("Lumigo plugin (node.js)", () => {
 
 		test("edgeHost configuration not present, should not appear in the wrapped code", async () => {
 			await lumigo.afterPackageInitialize();
-
 			expect(fs.outputFile).toBeCalledWith(
 				__dirname + "/_lumigo/hello.js",
 				expect.not.toContainAllStrings(`edgeHost:'${edgeHost}'`)

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -148,8 +148,8 @@ describe("Lumigo plugin (node.js)", () => {
 				test("should add mjs as file extension", async () => {
 					assertFileOutputES({
 						filename: "hello.js", 
-						importStatement: "import {world as lumigoHandler} from '../hello.mjs'",
-						exportStatement: "export const world = tracer.trace(lumigoHandler);"
+						importStatement: "import {world as originalHandler} from '../hello.mjs'",
+						exportStatement: "export const world = tracer.trace(originalHandler);"
 					});
 					expect(serverless.service.functions.hello.handler).toBe(
 						"_lumigo/hello.world"
@@ -879,28 +879,28 @@ function assertNodejsFunctionsAreWrappedES() {
 	[
 		{ 
 			filename: "hello.js", 
-			importStatement: "import {world as lumigoHandler} from '../hello.js'",
-			exportStatement: "export const world = tracer.trace(lumigoHandler);"
+			importStatement: "import {world as originalHandler} from '../hello.js'",
+			exportStatement: "export const world = tracer.trace(originalHandler);"
 		},
 		{ 
 			filename: "hello.world.js", 
-			importStatement: "import {handler as lumigoHandler} from '../hello.world.js'",
-			exportStatement: "export const handler = tracer.trace(lumigoHandler);"
+			importStatement: "import {handler as originalHandler} from '../hello.world.js'",
+			exportStatement: "export const handler = tracer.trace(originalHandler);"
 		},
 		{ 
 			filename: "foo.js", 
-			importStatement: "import {handler as lumigoHandler} from '../foo_bar.js'",
-			exportStatement: "export const handler = tracer.trace(lumigoHandler);"
+			importStatement: "import {handler as originalHandler} from '../foo_bar.js'",
+			exportStatement: "export const handler = tracer.trace(originalHandler);"
 		},
 		{ 
 			filename: "jet.js", 
-			importStatement: "import {handler as lumigoHandler} from '../foo/foo/bar.js'",
-			exportStatement: "export const handler = tracer.trace(lumigoHandler);"
+			importStatement: "import {handler as originalHandler} from '../foo/foo/bar.js'",
+			exportStatement: "export const handler = tracer.trace(originalHandler);"
 		},
 		{ 
 			filename: "pack.js", 
-			importStatement: "import {handler as lumigoHandler} from '../foo.bar/zoo.js'",
-			exportStatement: "export const handler = tracer.trace(lumigoHandler);"
+			importStatement: "import {handler as originalHandler} from '../foo.bar/zoo.js'",
+			exportStatement: "export const handler = tracer.trace(originalHandler);"
 		},
 	].forEach(assertFileOutputES);
 


### PR DESCRIPTION
Currently it seems the serverless-lumigo-plugin doesn't support Lambdas using ES6 modules. This PR adds such support and some related tests.