### PR TITLE
fix: compatible old sls versions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,11 @@ class LumigoPlugin {
 	}
 
 	extendServerlessSchema() {
-		if (this.serverless.configSchemaHandler && typeof this.serverless.configSchemaHandler.defineFunctionProperties === "function") {
+		if (
+			this.serverless.configSchemaHandler &&
+			typeof this.serverless.configSchemaHandler.defineFunctionProperties ===
+				"function"
+		) {
 			this.serverless.configSchemaHandler.defineFunctionProperties("aws", {
 				type: "object",
 				properties: {

--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,7 @@ class LumigoPlugin {
 	}
 
 	extendServerlessSchema() {
-		if (this.serverless.configSchemaHandler) {
+		if (this.serverless.configSchemaHandler && typeof this.serverless.configSchemaHandler.defineFunctionProperties === "function") {
 			this.serverless.configSchemaHandler.defineFunctionProperties("aws", {
 				type: "object",
 				properties: {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -100,6 +100,14 @@ describe("Invalid plugin configuration", () => {
 	});
 });
 
+describe("Old serverless compatibility", () => {
+	test("Schema validation", async () => {
+		// This is the case in serverless version 1.83.3
+		serverless.configSchemaHandler = {};
+		expect(lumigo.extendServerlessSchema()).resolves;
+	});
+});
+
 describe("Lumigo plugin (node.js)", () => {
 	const runtimes = [["nodejs14.x"], ["nodejs12.x"], ["nodejs10.x"]];
 	describe.each(runtimes)("when using runtime %s", runtime => {


### PR DESCRIPTION
This plugin is incompatible with old versions of the serverless framework (https://github.com/serverless/serverless/tags).
This change was validated on 2.72.2 (which was always supported) and now also 1.81.1 and 1.83.3