### PR TITLE
fix: custom provider layers missing with esbuild

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -272,7 +272,9 @@ class LumigoPlugin {
 
 			for (const func of functions) {
 				const funcRuntime = func.runtime || runtime;
-				func.layers = func.layers || [];
+				func.layers = func.layers || [
+					...(this.serverless.service.provider.layers || [])
+				];
 				const layer = await this.getLayerArn(funcRuntime);
 				func.layers.push(layer);
 				func.environment = func.environment || {};

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -399,6 +399,23 @@ describe("Lumigo plugin (node.js)", () => {
 
 				assertNodejsFunctionsHaveLayers();
 			});
+
+			test("custom layers configured at provider level are retained", async () => {
+				serverless.service.provider.layers = ["custom-layer"];
+
+				await lumigo.afterCreateDeploymentArtifacts();
+
+				console.log(serverless.service.functions);
+				const wrappedFunction = serverless.service.functions.hello;
+				expect(wrappedFunction.layers).not.toBeUndefined();
+				expect(wrappedFunction.layers).toHaveLength(2);
+				expect(wrappedFunction.layers[0]).toEqual("custom-layer");
+				expect(wrappedFunction.layers[1]).toEqual(
+					expect.stringMatching(
+						/arn:aws:lambda:us-east-1:114300393969:layer:lumigo-node-tracer:\d+/
+					)
+				);
+			});
 		});
 
 		describe("when useLayers is true", () => {


### PR DESCRIPTION
We have configured custom layers at provider.layers and use serverless-esbuild. Our custom layers are missing when using serverless-lumigo-plugin.